### PR TITLE
Add test flag builder and standardize world setup

### DIFF
--- a/tests/at1_placement.js
+++ b/tests/at1_placement.js
@@ -6,8 +6,7 @@
 //  - Invalid (overlap) placement ignored
 //  - No overlaps after valid placements
 
-import { World } from '../src/physics/world.js';
-import { GameState } from '../src/game/state.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import fs from 'fs';
 
 const CONFIG = { circleDiameter:700, rectWidth:120, rectHeight:80, timeStep:1/60 };
@@ -32,10 +31,7 @@ function attemptPlace(state, x, y){
 }
 
 function runAT1(){
-  const world = new World(CONFIG);
-  const state = new GameState(world, CONFIG);
-  // Ensure arena sync
-  state.applyArenaFlags && state.applyArenaFlags();
+  const { world, state } = buildPresetWorld(CONFIG);
 
   const results = { addedValid: false, blockedOutside:false, blockedOverlap:false, noOverlap:true };
 

--- a/tests/at24_metrics_diag_hash.js
+++ b/tests/at24_metrics_diag_hash.js
@@ -1,5 +1,5 @@
 // AT24 Diagnostics Hash: ensure diagnostics flag adds DIAG segment and is deterministic across runs.
-import { World } from '../src/physics/world.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import { createBrick, _resetBrickIdsForTest } from '../src/interaction/mouse.js';
 
 const CONFIG = { circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 };
@@ -12,7 +12,7 @@ function fnv(parts){
 
 function setupWorld(enableDiag){
   _resetBrickIdsForTest();
-  const w = new World(CONFIG);
+  const { world: w } = buildPresetWorld(CONFIG);
   w.lastTime = 0;
   const placements = [
     [-150,-40],[-10,-40],[130,-40],

--- a/tests/at24_metrics_hash.js
+++ b/tests/at24_metrics_hash.js
@@ -1,5 +1,5 @@
 // AT24 Metrics Hash Determinism: enabling determinism metrics should produce identical hash across runs.
-import { World } from '../src/physics/world.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import { createBrick, _resetBrickIdsForTest } from '../src/interaction/mouse.js';
 
 const CONFIG = { circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 };
@@ -12,7 +12,7 @@ function fnv(parts){
 
 function setupWorld(){
   _resetBrickIdsForTest();
-  const w = new World(CONFIG);
+  const { world: w } = buildPresetWorld(CONFIG);
   w.lastTime = 0;
   const placements = [
     [-150,-40],[-10,-40],[130,-40],

--- a/tests/at_containment_shrink_hash.js
+++ b/tests/at_containment_shrink_hash.js
@@ -1,10 +1,10 @@
 // 4.1d Containment shrink sequence hash determinism & outOfBounds fallback
-import { World } from '../src/physics/world.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import { createBrick, _resetBrickIdsForTest } from '../src/interaction/mouse.js';
 
 function buildWorld(){
   _resetBrickIdsForTest();
-  const w = new World({ circleDiameter:1200, rectWidth:120, rectHeight:80, timeStep:1/60 });
+  const { world: w } = buildPresetWorld({ circleDiameter:1200, rectWidth:120, rectHeight:80, timeStep:1/60 });
   w.lastTime = 0;
   // Place several bricks at different radii
   const placements = [

--- a/tests/at_forbidden_polys.js
+++ b/tests/at_forbidden_polys.js
@@ -1,11 +1,9 @@
 // AT 6.2 Forbidden polygons placement rejection test
-import { World } from '../src/physics/world.js';
-import { GameState } from '../src/game/state.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import { createBrick, _resetBrickIdsForTest } from '../src/interaction/mouse.js';
 
 _resetBrickIdsForTest();
-const world = new World({ circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 });
-const state = new GameState(world, { circleDiameter:800, rectWidth:120, rectHeight:80 });
+const { world, state } = buildPresetWorld({ circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 });
 
 // Define a triangle centered near origin
 state.setForbiddenPolys([

--- a/tests/at_mouse_spring_diag_hash.js
+++ b/tests/at_mouse_spring_diag_hash.js
@@ -1,5 +1,5 @@
 // 4.2d Mouse spring displacement appears only in DIAG segment when diagnostics enabled
-import { World } from '../src/physics/world.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import { createBrick, _resetBrickIdsForTest } from '../src/interaction/mouse.js';
 
 function fnv(parts){ let h=2166136261>>>0; const str=parts.join('|'); for (let i=0;i<str.length;i++){ h^=str.charCodeAt(i); h=Math.imul(h,16777619)>>>0;} return { hash:h.toString(16), raw:str }; }
@@ -20,7 +20,7 @@ function snapshot(w){
 
 function run(simSpring){
   _resetBrickIdsForTest();
-  const w=new World({ circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 });
+  const { world: w } = buildPresetWorld({ circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 });
   w.enableDeterminismMetrics();
   w.enableDeterminismDiagnostics();
   if (simSpring){

--- a/tests/at_move_batching.js
+++ b/tests/at_move_batching.js
@@ -1,11 +1,9 @@
 // 4.3 MoveCommand batching acceptance test
-import { World } from '../src/physics/world.js';
-import { GameState } from '../src/game/state.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import { createBrick, _resetBrickIdsForTest } from '../src/interaction/mouse.js';
 
 _resetBrickIdsForTest();
-const world = new World({ circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 });
-const state = new GameState(world, { circleDiameter:800, rectWidth:120, rectHeight:80 });
+const { world, state } = buildPresetWorld({ circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 });
 const b = createBrick(0,0,120,80); state.addBrick(b); state.select(b);
 // Simulate a drag with multiple incremental moves
 let from = { x: b.pos.x, y: b.pos.y };

--- a/tests/at_sleeping_hash.js
+++ b/tests/at_sleeping_hash.js
@@ -1,12 +1,12 @@
 // 2.10 Sleeping-system determinism: enabling sleeping must not change hash.
-import { World } from '../src/physics/world.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import { createBrick, _resetBrickIdsForTest } from '../src/interaction/mouse.js';
 
 const CONFIG = { timeStep:1/60, rectWidth:120, rectHeight:80 };
 
 function setupWorld(enableSleeping){
   _resetBrickIdsForTest();
-  const w = new World(CONFIG);
+  const { world: w } = buildPresetWorld(CONFIG);
   w.lastTime = 0;
   const placements = [
     [-200,-40],[-40,-40],[120,-40],

--- a/tests/at_undo_redo_sequence.js
+++ b/tests/at_undo_redo_sequence.js
@@ -1,11 +1,9 @@
 // AT6 Undo/Redo sequence integrity
-import { World } from '../src/physics/world.js';
-import { GameState } from '../src/game/state.js';
+import { buildPresetWorld } from './helpers/flagBuilder.js';
 import { createBrick, _resetBrickIdsForTest } from '../src/interaction/mouse.js';
 
 _resetBrickIdsForTest();
-const world = new World({ circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 });
-const state = new GameState(world, { circleDiameter:800, rectWidth:120, rectHeight:80 });
+const { world, state } = buildPresetWorld({ circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 });
 
 // Place 5 bricks via command stack so they are undoable
 const bricks=[];

--- a/tests/helpers/flagBuilder.js
+++ b/tests/helpers/flagBuilder.js
@@ -1,0 +1,13 @@
+import { World } from '../../src/physics/world.js';
+import { GameState } from '../../src/game/state.js';
+
+export function buildPresetWorld(config = { circleDiameter:800, rectWidth:120, rectHeight:80, timeStep:1/60 }){
+  const world = new World(config);
+  const state = new GameState(world, config);
+  if (state.applyArenaFlags) state.applyArenaFlags();
+  world.enableSpatialHash && world.enableSpatialHash({ cellSize:128 });
+  state.setNudgeEnabled && state.setNudgeEnabled(true);
+  state.setAutoPackEnabled && state.setAutoPackEnabled(true);
+  world.enableAdvancedFriction && world.enableAdvancedFriction();
+  return { world, state };
+}


### PR DESCRIPTION
## Summary
- add `buildPresetWorld` helper enabling spatial hash, nudge, autoPack and advanced friction
- refactor acceptance tests to construct worlds with the new preset builder

## Testing
- `node tests/at1_placement.js`
- `node tests/at_forbidden_polys.js`
- `node tests/at_move_batching.js`
- `node tests/at_undo_redo_sequence.js`
- `node tests/at24_metrics_hash.js`
- `node tests/at24_metrics_diag_hash.js`
- `node tests/at_containment_shrink_hash.js`
- `node tests/at_mouse_spring_diag_hash.js`
- `node tests/at_sleeping_hash.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab326095dc832ba43c5cffefe9f3bb